### PR TITLE
Change order of venv activation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ brew update && brew install jq && brew install npm && sudo npm install pm2 -g &&
 
 Inside the repository directory (time-series-prediction-subnet) run:
 python3 -m venv venv
-pip install -r requirements.txt
 source venv/bin/activate
+pip install -r requirements.txt
 
 4. Run the run.sh script which will handle running your validator and pulling the latest updates as they are issued.
 pm2 start run.sh --name sn8 -- --wallet.name <wallet> --wallet.hotkey <hotkey> --netuid 8


### PR DESCRIPTION
Should activate the python venv before attempting to install requirements in it.