### PR TITLE
Fixes for scoring and time unit tests

### DIFF
--- a/meta/meta.json
+++ b/meta/meta.json
@@ -1,4 +1,4 @@
 {
-  "subnet_version": "6.1.0",
+  "subnet_version": "6.2.0",
   "mining_model_version": "5.0.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bittensor==6.7.0
+bittensor==6.8.1
 coinmetrics-api-client>=2024.2.6.16
 keras==2.13.1
 matplotlib>=3.8.3

--- a/tests/vali_tests/test_scoring.py
+++ b/tests/vali_tests/test_scoring.py
@@ -118,11 +118,11 @@ class TestScoring(TestBase):
         )
 
     def test_get_geometric_mean_of_percentile(self):
-        ds = [[], [30000, 30100, 30150, 30200]]
+        ds = np.array([30000, 30100, 30150, 30200])
 
-        mean = np.mean(ds[1])
-        squared_diff = np.sum((ds[1] - mean) ** 2)
-        std_dev = np.sqrt(squared_diff / len(ds[1]))
+        mean = np.mean(ds)
+        squared_diff = np.sum((ds - mean) ** 2)
+        std_dev = np.sqrt(squared_diff / len(ds))
 
         min_max = 1.006666666666667
 
@@ -151,7 +151,7 @@ class TestScoring(TestBase):
             pass
 
         scores = [("miner1", 0.1), ("miner2", 0.2), ("miner3", 0.3), ("miner4", 0.4)]
-        ds = [[], [30000, 30100, 30150, 30200]]
+        ds = np.array([30000, 30100, 30150, 30200])
 
         (
             vweights,
@@ -176,7 +176,7 @@ class TestScoring(TestBase):
         self.assertEqual(vweights, set_vweights)
 
         scores.pop()
-        ds = [[], [30000, 30100, 30150]]
+        ds = np.array([30000, 30100, 30150])
 
         # testing if we remove a miner their score begins to drop
 
@@ -198,7 +198,7 @@ class TestScoring(TestBase):
         # testing adding a new miner that they fit to the average even if the scores
         # have a larger magnitude move
 
-        ds = [[], [30000, 3100, 32000]]
+        ds = np.array([30000, 3100, 32000])
         scores.append(("miner5", 0.5))
 
         (
@@ -231,7 +231,7 @@ class TestScoring(TestBase):
             pass
 
         scores = [("miner1", 0.1), ("miner2", 0.2), ("miner3", 0.3), ("miner4", 0.4)]
-        ds = [[], [30000, 30100, 30150, 30200]]
+        ds = np.array([30000, 30100, 30150, 30200])
 
         (
             vweights,
@@ -257,11 +257,26 @@ class TestScoring(TestBase):
         )
 
     def test_update_weights_using_historical_distributions_with_dummy_data(self):
-        scores = [("miner1", 0.1), ("miner2", 0.2), ("miner3", 0.3), ("miner4", 0.4)]
-        data = [[], [10, 20, 30, 40]]
-        updated_scores = Scoring.update_weights_using_historical_distributions(
-            scores, data
-        )
+        scores = [
+            ("miner1", 0.1),
+            ("miner2", 0.2),
+            ("miner3", 0.3),
+            ("miner4", 0.4),
+        ]
+        expected_scores = {
+            "miner1": 0.0003710575139146568,
+            "miner2": 0.0007421150278293136,
+            "miner3": 0.00111317254174397,
+            "miner4": 0.0014842300556586272,
+        }
+        expected_gmof = 0.1
+        data = np.array([10, 20, 30, 40])
+        (
+            updated_scores,
+            geometric_mean_of_percentile,
+        ) = Scoring.update_weights_using_historical_distributions(scores, data)
+        self.assertEqual(geometric_mean_of_percentile, expected_gmof)
+        self.assertEqual(updated_scores, expected_scores)
 
     def test_calculate_directional_accuracy(self):
         predictions = [1, 2, 1, 3, 4, 5, 6, 7, 6, 7, 8]

--- a/tests/vali_tests/test_time_util.py
+++ b/tests/vali_tests/test_time_util.py
@@ -1,20 +1,17 @@
 # developer: Taoshidev
 # Copyright © 2023 Taoshi Inc
-
 import time
-import unittest
-from datetime import datetime
-
-from tests.vali_tests.samples.testing_data import TestingData
+from time_util import datetime
 from time_util.time_util import TimeUtil
-from vali_config import ValiConfig
+import unittest
 
 
 class TestTimeUtil(unittest.TestCase):
-
     def test_now_in_millis(self):
         self.assertTrue(int(datetime.now().timestamp() * 1000) > 1694482321729)
-        self.assertAlmostEqual(int(datetime.utcnow().timestamp() * 1000), TimeUtil.now_in_millis())  # add assertion here
+        self.assertAlmostEqual(
+            int(datetime.utcnow().timestamp() * 1000), TimeUtil.now_in_millis()
+        )
 
     def test_convert_millis_to_timestamp(self):
         time.sleep(1)
@@ -25,28 +22,30 @@ class TestTimeUtil(unittest.TestCase):
         start = TimeUtil.generate_start_timestamp(0)
         ms = TimeUtil.timestamp_to_millis(start)
         updated_start = TimeUtil.millis_to_timestamp(ms)
-        self.assertEqual([updated_start.day, start.hour, start.minute], [updated_start.day, updated_start.hour, start.minute])
+        self.assertEqual(
+            [updated_start.day, start.hour, start.minute],
+            [updated_start.day, updated_start.hour, start.minute],
+        )
 
     def test_generate_start_timestamp(self):
         older_time = TimeUtil.generate_start_timestamp(1)
-        self.assertGreater(TimeUtil.timestamp_to_millis(self._t), TimeUtil.timestamp_to_millis(older_time))
-
-    # def test_generate_range_timestamps(self):
-    #     start = TestingData.test_start_time
-    #     generated_timestamps = TimeUtil.generate_range_timestamps(start, 5)
-    #     self.assertEqual(TestingData.test_generated_timestamps, generated_timestamps)
+        self.assertGreater(
+            TimeUtil.timestamp_to_millis(self._t),
+            TimeUtil.timestamp_to_millis(older_time),
+        )
 
     def test_generating_start_end_results(self):
         dt = datetime(2023, 9, 19, 12, 0, 0)
         training_results_start = int(TimeUtil.timestamp_to_millis(dt))
-        training_results_end = TimeUtil.timestamp_to_millis(dt) + \
-                               TimeUtil.minute_in_millis(25 * ValiConfig.STANDARD_TF)
-        print((training_results_start, training_results_end))
-        self.assertEqual((training_results_start, training_results_end), (1695150000000, 1695157500000))
+        training_results_end = training_results_start + TimeUtil.minute_in_millis(25)
+        self.assertEqual(
+            (training_results_start, training_results_end),
+            (1695124800000, 1695126300000),
+        )
 
     def setUp(self) -> None:
         self._t = datetime.now()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Taoshi Pull Request

### Description
Fixes unit tests that were broken due to datasets only including predictions and times tests not including time zone information.

### Related Issues (JIRA)
N/A

### Checklist
- [X] I have tested my changes on testnet.
- [X] I have updated any necessary documentation.
- [X] I have added unit tests for my changes (if applicable).
- [X] If there are breaking changes for validators, I have (or will) notify the community in Discord of the release.

### Reviewer Instructions
N/A

### Definition of Done
- [X] Code has been reviewed.
- [X] All checks and tests pass.
- [X] Documentation is up to date.
- [X] Approved by at least one reviewer.

### Checklist (for the reviewer)
- [X] Code follows project conventions.
- [X] Code is well-documented.
- [X] Changes are necessary and align with the project's goals.
- [X] No breaking changes introduced.

### Optional: Deploy Notes
N/A
