### PR TITLE
fix(miner): Update neurons/miner.py to accept external_ip argument.

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -519,7 +519,7 @@ def main(config):
     bt.logging.info(f"setting port [{config.axon.port}]")
     bt.logging.info(f"setting external port [{config.axon.external_port}]")
     axon = bt.axon(
-        wallet=wallet, port=config.axon.port, external_port=config.axon.external_port
+        wallet=wallet, port=config.axon.port, external_port=config.axon.external_port, external_ip=config.axon.external_ip
     )
     bt.logging.info(f"Axon {axon}")
 


### PR DESCRIPTION
It was accepting external port but not external ip.

it is a valid input per these docs:
https://docs.neuralinternet.ai/products/subnet-27-compute/bittensor-compute-subnet-miner-setup

## Taoshi Pull Request

### Description
[Provide a brief description of the changes introduced by this pull request.]

### Related Issues (JIRA)
[Reference any related issues or tasks that this pull request addresses or closes.]

### Checklist
- [ ] I have tested my changes on testnet.
- [ ] I have updated any necessary documentation.
- [ ] I have added unit tests for my changes (if applicable).
- [ ] If there are breaking changes for validators, I have (or will) notify the community in Discord of the release.

### Reviewer Instructions
[Provide any specific instructions or areas you would like the reviewer to focus on.]

### Definition of Done
- [ ] Code has been reviewed.
- [ ] All checks and tests pass.
- [ ] Documentation is up to date.
- [ ] Approved by at least one reviewer.

### Checklist (for the reviewer)
- [ ] Code follows project conventions.
- [ ] Code is well-documented.
- [ ] Changes are necessary and align with the project's goals.
- [ ] No breaking changes introduced.

### Optional: Deploy Notes
[Any instructions or notes related to deployment, if applicable.]

/cc @mention_reviewer
